### PR TITLE
stride and slice

### DIFF
--- a/docs/next-js/components/loading/LocalNetCDFMeta.tsx
+++ b/docs/next-js/components/loading/LocalNetCDFMeta.tsx
@@ -30,6 +30,11 @@ import {
 } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { NetCDF4, DataTree, GroupNode } from '@earthyscience/netcdf4-wasm';
+import SliceTesterSection, {
+  SliceSelectionState,
+  defaultSelection,
+  buildSelection,
+} from './SliceTester';
 
 const NETCDF_EXT_REGEX = /\.(nc|netcdf|nc3|nc4)$/i;
 
@@ -68,9 +73,62 @@ const LocalNetCDFMeta = () => {
   const [showVariableMenu, setShowVariableMenu] = useState(false);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set(['/']));
 
-  // ---------------------------------------------------------------------------
+  // ── Slice tester state ─────────────────────────────────────────────────────
+  const [expandedSliceTester, setExpandedSliceTester] = useState(false);
+  const [sliceSelections, setSliceSelections] = useState<SliceSelectionState[]>([]);
+  const [sliceResult, setSliceResult] = useState<any>(null);
+  const [sliceError, setSliceError] = useState<string | null>(null);
+  const [loadingSlice, setLoadingSlice] = useState(false);
+
+  // Reset slice tester when selected variable changes
+  useEffect(() => {
+    setSliceResult(null);
+    setSliceError(null);
+    setExpandedSliceTester(false);
+    if (selectedVariable && variables[selectedVariable]?.info?.shape) {
+      setSliceSelections(
+        (variables[selectedVariable].info.shape as any[]).map(() => defaultSelection())
+      );
+    } else {
+      setSliceSelections([]);
+    }
+  }, [selectedVariable]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Init slice selections when info first loads for the selected variable
+  useEffect(() => {
+    if (
+      selectedVariable &&
+      variables[selectedVariable]?.info?.shape &&
+      sliceSelections.length === 0
+    ) {
+      setSliceSelections(
+        (variables[selectedVariable].info.shape as any[]).map(() => defaultSelection())
+      );
+    }
+  }, [variables, selectedVariable]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const runSliceTest = useCallback(async () => {
+    if (!dataset || !selectedVariable) return;
+    setLoadingSlice(true);
+    setSliceError(null);
+    setSliceResult(null);
+    try {
+      const info = variables[selectedVariable].info;
+      const selection = buildSelection(sliceSelections, info.shape);
+      const data = await dataset.get(
+        selectedVariable,
+        selection,
+        currentGroupPath === '/' ? undefined : currentGroupPath
+      );
+      setSliceResult(data);
+    } catch (e: any) {
+      setSliceError(e?.message ?? String(e));
+    } finally {
+      setLoadingSlice(false);
+    }
+  }, [dataset, selectedVariable, variables, sliceSelections, currentGroupPath]);
+
   // Helpers wrapped in useCallback
-  // ---------------------------------------------------------------------------
   
   const refreshGroup = useCallback((path: string, dataTree: DataTree) => {
     setCurrentGroupPath(path);
@@ -139,7 +197,6 @@ const LocalNetCDFMeta = () => {
         // Create start and count arrays
         const start = new Array(shape.length).fill(0);
         const count = [...shape];
-        // Slice along the first dimension
         count[0] = Math.min(actualSize, shape[0]);
         const data = await dataset.getSlicedVariableArray(
           varName,
@@ -186,24 +243,18 @@ const LocalNetCDFMeta = () => {
       setError('Please enter a URL.');
       return false;
     }
-    
-    // Check for common protocols
     const validProtocols = ['http://', 'https://', 's3://', 'gs://', 'ftp://'];
     const hasValidProtocol = validProtocols.some(protocol => 
       urlString.toLowerCase().startsWith(protocol)
     );
-    
     if (!hasValidProtocol) {
       setError('URL must start with a valid protocol (http://, https://, s3://, gs://, or ftp://)');
       return false;
     }
-    
-    // Check if URL ends with NetCDF extension
     if (!NETCDF_EXT_REGEX.test(urlString)) {
       setError('URL should point to a NetCDF file (.nc, .netcdf, .nc3, .nc4)');
       return false;
     }
-    
     return true;
   };
 
@@ -211,24 +262,18 @@ const LocalNetCDFMeta = () => {
     setError(null);
     const files = event.target.files;
     if (!files || files.length === 0) return;
-
     const file = files[0];
-
     if (!NETCDF_EXT_REGEX.test(file.name)) {
       setError('Please select a valid NetCDF file.');
       return;
     }
-
     try {
       setIsLoading(true);
-
       const ds = await NetCDF4.fromBlobLazy(file);
       const dt = new DataTree(ds);
       await dt.buildTree();
-
       setDataset(ds);
       setTree(dt);
-
       refreshGroup('/', dt);
     } catch (err) {
       console.error(err);
@@ -240,22 +285,14 @@ const LocalNetCDFMeta = () => {
 
   const handleUrlFetch = async () => {
     setError(null);
-
-    if (!validateUrl(url)) {
-      return;
-    }
-
+    if (!validateUrl(url)) return;
     try {
       setIsLoading(true);
-      // const urlTry = await NetCDF4.Dataset("s3://its-live-data/test-space/sample-data/sst.mnmean.nc")
-      // console.log(urlTry)
       const ds = await NetCDF4.Dataset(url);
       const dt = new DataTree(ds);
       await dt.buildTree();
-
       setDataset(ds);
       setTree(dt);
-
       refreshGroup('/', dt);
     } catch (err) {
       console.error(err);
@@ -272,12 +309,9 @@ const LocalNetCDFMeta = () => {
   const selectGroup = (path: string) => {
     if (!tree) return;
     refreshGroup(path, tree);
-    // Open the group menu and close the variable menu
     setShowGroupMenu(true);
     setShowVariableMenu(false);
-    // Expand the selected group and all its parents
     const newExpanded = new Set(expandedGroups);
-    // Add all parent paths
     const parts = path.split('/').filter(Boolean);
     let currentPath = '/';
     newExpanded.add(currentPath);
@@ -299,8 +333,6 @@ const LocalNetCDFMeta = () => {
       setShowSearchResults(false);
       return;
     }
-
-    // Show partial matches while typing
     if (tree) {
       const results = tree.searchVariables(value);
       setSearchResults(results);
@@ -414,10 +446,7 @@ const LocalNetCDFMeta = () => {
                         size="sm" 
                         onClick={() => {
                           setShowVariableMenu(!showVariableMenu);
-                          // Close group menu when opening variable menu
-                          if (!showVariableMenu) {
-                            setShowGroupMenu(false);
-                          }
+                          if (!showVariableMenu) setShowGroupMenu(false);
                         }}
                         className="cursor-pointer flex-shrink-0"
                       >
@@ -435,8 +464,7 @@ const LocalNetCDFMeta = () => {
                       <p>Variables in current group</p>
                     </TooltipContent>
                   </Tooltip>
-                )
-                }
+                )}
 
                 {/* Search */}
                 <div className="flex gap-1 flex-1 min-w-[180px] sm:min-w-[200px] relative">
@@ -476,12 +504,8 @@ const LocalNetCDFMeta = () => {
                                 <div className="flex items-start gap-2">
                                   <FileText className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
                                   <div className="flex-1 min-w-0">
-                                    <div className="font-mono text-sm break-all">
-                                      {result.name}
-                                    </div>
-                                    <div className="text-xs text-muted-foreground mt-0.5 break-all">
-                                      {result.groupPath}
-                                    </div>
+                                    <div className="font-mono text-sm break-all">{result.name}</div>
+                                    <div className="text-xs text-muted-foreground mt-0.5 break-all">{result.groupPath}</div>
                                   </div>
                                 </div>
                               </button>
@@ -496,58 +520,50 @@ const LocalNetCDFMeta = () => {
                     </>
                   )}
                 </div>
+
                 {/* Group Summary */}
                 <div className="flex flex-col gap-3">
-                {groupSummary && (
-                  <div className="flex gap-2 sm:gap-3 text-xs flex-wrap">
-                    <Badge variant="outline" className="flex-shrink-0">
-                      {groupSummary.variableCount} variables
-                    </Badge>
-                    <Badge variant="outline" className="flex-shrink-0">
-                      {groupSummary.dimensionCount} dimensions
-                    </Badge>
-                    <Badge variant="outline" className="flex-shrink-0">
-                      {groupSummary.attributeCount} attributes
-                    </Badge>
-                    {groupSummary.subgroupCount > 0 && (
-                      <Badge variant="outline" className="flex-shrink-0">
-                        {groupSummary.subgroupCount} subgroups
+                  {groupSummary && (
+                    <div className="flex gap-2 sm:gap-3 text-xs flex-wrap">
+                      <Badge variant="outline" className="flex-shrink-0">{groupSummary.variableCount} variables</Badge>
+                      <Badge variant="outline" className="flex-shrink-0">{groupSummary.dimensionCount} dimensions</Badge>
+                      <Badge variant="outline" className="flex-shrink-0">{groupSummary.attributeCount} attributes</Badge>
+                      {groupSummary.subgroupCount > 0 && (
+                        <Badge variant="outline" className="flex-shrink-0">{groupSummary.subgroupCount} subgroups</Badge>
+                      )}
+                    </div>
+                  )}
+                  {/* Breadcrumbs */}
+                  <div className="flex items-center gap-2 text-xs flex-wrap">
+                    <div className="flex items-center gap-1 text-muted-foreground flex-wrap">
+                      {breadcrumbs.map((crumb, idx) => (
+                        <React.Fragment key={crumb.path}>
+                          <button
+                            onClick={() => selectGroup(crumb.path)}
+                            className={`hover:text-foreground transition-colors cursor-pointer break-all ${
+                              crumb.path === currentGroupPath ? 'text-foreground font-semibold' : ''
+                            }`}
+                          >
+                            {crumb.name}
+                          </button>
+                          {idx < breadcrumbs.length - 1 && (
+                            <ChevronRight className="h-3 w-3 flex-shrink-0" />
+                          )}
+                        </React.Fragment>
+                      ))}
+                    </div>
+                    {selectedVariable && (
+                      <Badge 
+                        className="text-xs h-5 max-w-full"
+                        style={{ backgroundColor: '#644FF0', color: 'white' }}
+                      >
+                        <FileText className="h-3 w-3 mr-1 flex-shrink-0" />
+                        <span className="truncate">{selectedVariable}</span>
                       </Badge>
                     )}
                   </div>
-                )}
-                {/* Breadcrumbs */}
-              <div className="flex items-center gap-2 text-xs flex-wrap">
-                <div className="flex items-center gap-1 text-muted-foreground flex-wrap">
-                  {breadcrumbs.map((crumb, idx) => (
-                    <React.Fragment key={crumb.path}>
-                      <button
-                        onClick={() => selectGroup(crumb.path)}
-                        className={`hover:text-foreground transition-colors cursor-pointer break-all ${
-                          crumb.path === currentGroupPath ? 'text-foreground font-semibold' : ''
-                        }`}
-                      >
-                        {crumb.name}
-                      </button>
-                      {idx < breadcrumbs.length - 1 && (
-                        <ChevronRight className="h-3 w-3 flex-shrink-0" />
-                      )}
-                    </React.Fragment>
-                  ))}
                 </div>
-                
-                {selectedVariable && (
-                  <Badge 
-                    className="text-xs h-5 max-w-full"
-                    style={{ backgroundColor: '#644FF0', color: 'white' }}
-                  >
-                    <FileText className="h-3 w-3 mr-1 flex-shrink-0" />
-                    <span className="truncate">{selectedVariable}</span>
-                  </Badge>
-                )}
               </div>
-              </div>
-            </div>
 
               {/* Group Menu (Expandable) */}
               {showGroupMenu && (
@@ -557,18 +573,13 @@ const LocalNetCDFMeta = () => {
                     
                     const toggleGroup = (path: string) => {
                       const newExpanded = new Set(expandedGroups);
-                      if (newExpanded.has(path)) {
-                        newExpanded.delete(path);
-                      } else {
-                        newExpanded.add(path);
-                      }
+                      if (newExpanded.has(path)) newExpanded.delete(path);
+                      else newExpanded.add(path);
                       setExpandedGroups(newExpanded);
                     };
 
                     const handleVariableClick = (varName: string, groupPath: string) => {
-                      if (currentGroupPath !== groupPath) {
-                        selectGroup(groupPath);
-                      }
+                      if (currentGroupPath !== groupPath) selectGroup(groupPath);
                       setPendingVariableLoad({ name: varName, groupPath });
                       setShowGroupMenu(false);
                     };
@@ -583,7 +594,6 @@ const LocalNetCDFMeta = () => {
                       return (
                         <div key={node.path}>
                           <div className="flex items-stretch gap-1" style={{ paddingLeft: `${level * 12}px` }}>
-                            {/* Group button - now just expands/collapses */}
                             <button
                               onClick={() => toggleGroup(node.path)}
                               className={`flex-1 text-left px-2 py-2 rounded text-sm flex items-center justify-between gap-2 hover:bg-accent/50 ${
@@ -591,40 +601,30 @@ const LocalNetCDFMeta = () => {
                               }`}
                             >
                               <div className="flex items-center gap-2 min-w-0 flex-1">
-                                {/* Chevron */}
                                 {(hasChildren || varNames.length > 0) ? (
-                                  isExpanded ? (
-                                    <ChevronDown className="h-3 w-3 flex-shrink-0" />
-                                  ) : (
-                                    <ChevronRight className="h-3 w-3 flex-shrink-0" />
-                                  )
+                                  isExpanded
+                                    ? <ChevronDown className="h-3 w-3 flex-shrink-0" />
+                                    : <ChevronRight className="h-3 w-3 flex-shrink-0" />
                                 ) : (
                                   <div className="w-3 h-3 flex-shrink-0" />
                                 )}
-                                {/* Folder icon */}
-                                {hasChildren ? (
-                                  <FolderOpen className="h-4 w-4 flex-shrink-0" />
-                                ) : (
-                                  <Folder className="h-4 w-4 flex-shrink-0" />
-                                )}
+                                {hasChildren
+                                  ? <FolderOpen className="h-4 w-4 flex-shrink-0" />
+                                  : <Folder className="h-4 w-4 flex-shrink-0" />
+                                }
                                 <span className="truncate">{node.name}</span>
                               </div>
                               <div className="flex gap-1 flex-shrink-0">
                                 {node.variableCount > 0 && (
-                                  <Badge variant="secondary" className="text-xs h-5">
-                                    {node.variableCount}
-                                  </Badge>
+                                  <Badge variant="secondary" className="text-xs h-5">{node.variableCount}</Badge>
                                 )}
                                 {hasChildren && (
-                                  <Badge variant="outline" className="text-xs h-5">
-                                    {node.children.length}
-                                  </Badge>
+                                  <Badge variant="outline" className="text-xs h-5">{node.children.length}</Badge>
                                 )}
                               </div>
                             </button>
                           </div>
 
-                          {/* Variables for this group (when expanded) */}
                           {isExpanded && varNames.length > 0 && (
                             <div style={{ paddingLeft: `${(level + 1) * 12 + 20}px` }} className="space-y-0.5 py-1">
                               {varNames.map(name => (
@@ -640,21 +640,17 @@ const LocalNetCDFMeta = () => {
                             </div>
                           )}
 
-                          {/* Child groups (when expanded) */}
                           {isExpanded && hasChildren && (
-                            <div>
-                              {node.children.map(child => renderGroupItem(child, level + 1))}
-                            </div>
+                            <div>{node.children.map(child => renderGroupItem(child, level + 1))}</div>
                           )}
                         </div>
                       );
                     };
 
-                    // Root group handling
                     const rootVars = tree.getAllVariables('/');
                     const rootVarNames = Object.keys(rootVars);
                     const isRootExpanded = expandedGroups.has('/');
-                    const ROOT_VARS_KEY = '/__root_vars__'; // Special key for root variables
+                    const ROOT_VARS_KEY = '/__root_vars__';
                     const isRootVarsExpanded = expandedGroups.has(ROOT_VARS_KEY);
 
                     return (
@@ -667,13 +663,10 @@ const LocalNetCDFMeta = () => {
                             }`}
                           >
                             <div className="flex items-center gap-2 min-w-0 flex-1">
-                              {/* Chevron for root */}
                               {(groupTree.children.length > 0 || rootVarNames.length > 0) ? (
-                                isRootExpanded ? (
-                                  <ChevronDown className="h-3 w-3 flex-shrink-0" />
-                                ) : (
-                                  <ChevronRight className="h-3 w-3 flex-shrink-0" />
-                                )
+                                isRootExpanded
+                                  ? <ChevronDown className="h-3 w-3 flex-shrink-0" />
+                                  : <ChevronRight className="h-3 w-3 flex-shrink-0" />
                               ) : (
                                 <div className="w-3 h-3 flex-shrink-0" />
                               )}
@@ -688,22 +681,18 @@ const LocalNetCDFMeta = () => {
                           </button>
                         </div>
 
-                        {/* Root variables section (when root is expanded) */}
                         {isRootExpanded && rootVarNames.length > 0 && (
                           <div style={{ paddingLeft: '12px' }}>
                             <button
                               onClick={() => toggleGroup(ROOT_VARS_KEY)}
                               className="w-full text-left px-2 py-1.5 rounded text-sm flex items-center gap-2 hover:bg-accent/50 text-muted-foreground"
                             >
-                              {isRootVarsExpanded ? (
-                                <ChevronDown className="h-3 w-3 flex-shrink-0" />
-                              ) : (
-                                <ChevronRight className="h-3 w-3 flex-shrink-0" />
-                              )}
+                              {isRootVarsExpanded
+                                ? <ChevronDown className="h-3 w-3 flex-shrink-0" />
+                                : <ChevronRight className="h-3 w-3 flex-shrink-0" />
+                              }
                               <span className="truncate">Variables ({rootVarNames.length})</span>
                             </button>
-                            
-                            {/* Root variables list (when variables section is expanded) */}
                             {isRootVarsExpanded && (
                               <div style={{ paddingLeft: '20px' }} className="space-y-0.5 py-1">
                                 {rootVarNames.map(name => (
@@ -721,7 +710,6 @@ const LocalNetCDFMeta = () => {
                           </div>
                         )}
 
-                        {/* Root child groups (when expanded) */}
                         {isRootExpanded && groupTree.children.map(child => renderGroupItem(child, 0))}
                       </>
                     );
@@ -766,133 +754,66 @@ const LocalNetCDFMeta = () => {
                         className="w-full flex items-center justify-between p-3 hover:bg-accent/50 transition-colors cursor-pointer"
                       >
                         <span className="text-sm font-semibold">Variable Info</span>
-                        {expandedVariableInfo ? (
-                          <ChevronDown className="h-4 w-4 flex-shrink-0" />
-                        ) : (
-                          <ChevronRight className="h-4 w-4 flex-shrink-0" />
-                        )}
+                        {expandedVariableInfo
+                          ? <ChevronDown className="h-4 w-4 flex-shrink-0" />
+                          : <ChevronRight className="h-4 w-4 flex-shrink-0" />
+                        }
                       </button>
                       
                       {expandedVariableInfo && (
                         <div className="max-h-[300px] overflow-y-auto px-3 pb-3 space-y-2 sm:space-y-1 text-xs overflow-x-auto">
-                          {/* Name */}
-                          <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                            <span className="font-mono text-muted-foreground">name:</span>
-                            <span className="font-mono break-all pl-4 sm:pl-0">
-                              {variables[selectedVariable].info.name}
-                            </span>
-                          </div>
-
-                          {/* Data Type */}
-                          <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                            <span className="font-mono text-muted-foreground">dtype:</span>
-                            <span className="font-mono break-all pl-4 sm:pl-0">
-                              {variables[selectedVariable].info.dtype}
-                            </span>
-                          </div>
-
-                          {/* NC Type */}
-                          {variables[selectedVariable].info.nctype !== undefined && (
-                            <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                              <span className="font-mono text-muted-foreground">nctype:</span>
-                              <span className="font-mono break-all pl-4 sm:pl-0">
-                                {variables[selectedVariable].info.nctype}
-                              </span>
+                          {[
+                            { label: 'name',      value: variables[selectedVariable].info.name },
+                            { label: 'dtype',     value: variables[selectedVariable].info.dtype },
+                            ...(variables[selectedVariable].info.nctype !== undefined
+                              ? [{ label: 'nctype', value: variables[selectedVariable].info.nctype }]
+                              : []),
+                            { label: 'shape',      value: `[${variables[selectedVariable].info.shape.join(', ')}]` },
+                            { label: 'dimensions', value: `[${variables[selectedVariable].info.dimensions?.join(', ') || 'N/A'}]` },
+                            { label: 'size',       value: variables[selectedVariable].info.size.toLocaleString() },
+                            ...(variables[selectedVariable].info.totalSize !== undefined
+                              ? [{ label: 'totalSize', value: `${variables[selectedVariable].info.totalSize.toLocaleString()} bytes` }]
+                              : []),
+                            ...(variables[selectedVariable].info.chunked !== undefined
+                              ? [{ label: 'chunked', value: String(variables[selectedVariable].info.chunked) }]
+                              : []),
+                            ...(variables[selectedVariable].info.chunks
+                              ? [{ label: 'chunks', value: `[${variables[selectedVariable].info.chunks.join(', ')}]` }]
+                              : []),
+                            ...(variables[selectedVariable].info.chunkSize !== undefined
+                              ? [{ label: 'chunkSize', value: `${variables[selectedVariable].info.chunkSize.toLocaleString()} bytes` }]
+                              : []),
+                          ].map(({ label, value }) => (
+                            <div key={label} className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
+                              <span className="font-mono text-muted-foreground">{label}:</span>
+                              <span className="font-mono break-all pl-4 sm:pl-0">{value}</span>
                             </div>
-                          )}
-
-                          {/* Shape */}
-                          <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                            <span className="font-mono text-muted-foreground">shape:</span>
-                            <span className="font-mono break-all pl-4 sm:pl-0">
-                              [{variables[selectedVariable].info.shape.join(', ')}]
-                            </span>
-                          </div>
-
-                          {/* Dimensions */}
-                          <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                            <span className="font-mono text-muted-foreground">dimensions:</span>
-                            <span className="font-mono break-all pl-4 sm:pl-0">
-                              [{variables[selectedVariable].info.dimensions?.join(', ') || 'N/A'}]
-                            </span>
-                          </div>
-
-                          {/* Size */}
-                          <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                            <span className="font-mono text-muted-foreground">size:</span>
-                            <span className="font-mono break-all pl-4 sm:pl-0">
-                              {variables[selectedVariable].info.size.toLocaleString()}
-                            </span>
-                          </div>
-
-                          {/* Total Size */}
-                          {variables[selectedVariable].info.totalSize !== undefined && (
-                            <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                              <span className="font-mono text-muted-foreground">totalSize:</span>
-                              <span className="font-mono break-all pl-4 sm:pl-0">
-                                {variables[selectedVariable].info.totalSize.toLocaleString()} bytes
-                              </span>
-                            </div>
-                          )}
-
-                          {/* Chunked */}
-                          {variables[selectedVariable].info.chunked !== undefined && (
-                            <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                              <span className="font-mono text-muted-foreground">chunked:</span>
-                              <span className="font-mono break-all pl-4 sm:pl-0">
-                                {String(variables[selectedVariable].info.chunked)}
-                              </span>
-                            </div>
-                          )}
-
-                          {/* Chunks */}
-                          {variables[selectedVariable].info.chunks && (
-                            <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                              <span className="font-mono text-muted-foreground">chunks:</span>
-                              <span className="font-mono break-all pl-4 sm:pl-0">
-                                [{variables[selectedVariable].info.chunks.join(', ')}]
-                              </span>
-                            </div>
-                          )}
-
-                          {/* Chunk Size */}
-                          {variables[selectedVariable].info.chunkSize !== undefined && (
-                            <div className="flex flex-col sm:grid sm:grid-cols-[150px_1fr] gap-0.5 sm:gap-2 min-w-0">
-                              <span className="font-mono text-muted-foreground">chunkSize:</span>
-                              <span className="font-mono break-all pl-4 sm:pl-0">
-                                {variables[selectedVariable].info.chunkSize.toLocaleString()} bytes
-                              </span>
-                            </div>
-                          )}
+                          ))}
                         </div>
                       )}
                     </div>
 
                     {/* Collapsible Enum Dictionary */}
                     {variables[selectedVariable].info.enum && 
-                    Object.keys(variables[selectedVariable].info.enum).length > 0 && (
+                     Object.keys(variables[selectedVariable].info.enum).length > 0 && (
                       <div className="border-0 rounded-lg overflow-hidden">
                         <button
                           onClick={() => setExpandedEnumDict(!expandedEnumDict)}
                           className="w-full flex items-center justify-between p-3 hover:bg-accent/50 transition-colors cursor-pointer"
                         >
                           <div className="flex items-center gap-2">
-                            <span className="text-sm font-semibold truncate">
-                              Values
-                            </span>
+                            <span className="text-sm font-semibold truncate">Values</span>
                             {variables[selectedVariable].info.enumType && (
                               <span className="text-xs text-muted-foreground font-mono">
                                 ({variables[selectedVariable].info.enumType.name})
                               </span>
                             )}
                           </div>
-                          {expandedEnumDict ? (
-                            <ChevronDown className="h-4 w-4 flex-shrink-0" />
-                          ) : (
-                            <ChevronRight className="h-4 w-4 flex-shrink-0" />
-                          )}
+                          {expandedEnumDict
+                            ? <ChevronDown className="h-4 w-4 flex-shrink-0" />
+                            : <ChevronRight className="h-4 w-4 flex-shrink-0" />
+                          }
                         </button>
-                        
                         {expandedEnumDict && (
                           <div className="max-h-[300px] overflow-y-auto px-3 pb-3 space-y-2 sm:space-y-1 text-xs overflow-x-auto">
                             <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
@@ -900,23 +821,18 @@ const LocalNetCDFMeta = () => {
                                 .sort(([a], [b]) => Number(a) - Number(b))
                                 .map(([value, label]) => (
                                   <React.Fragment key={value}>
-                                    <span className="font-mono text-muted-foreground text-right">
-                                      {value}:
-                                    </span>
-                                    <span className="font-mono break-all">
-                                      {String(label)}
-                                    </span>
+                                    <span className="font-mono text-muted-foreground text-right">{value}:</span>
+                                    <span className="font-mono break-all">{String(label)}</span>
                                   </React.Fragment>
                                 ))}
                             </div>
-                            
                             {variables[selectedVariable].info.enumType && (
                               <div className="mt-3 pt-3 border-t text-muted-foreground">
                                 <div className="flex items-center gap-2 text-xs">
                                   <span>Base Type:</span>
                                   <span className="font-mono">
                                     {variables[selectedVariable].info.dtype_base || 
-                                    `NC_TYPE_${variables[selectedVariable].info.enumType.baseType}`}
+                                     `NC_TYPE_${variables[selectedVariable].info.enumType.baseType}`}
                                   </span>
                                 </div>
                               </div>
@@ -937,24 +853,19 @@ const LocalNetCDFMeta = () => {
                           <span className="text-sm font-semibold truncate">
                             Variable Attributes ({Object.keys(variables[selectedVariable].info.attributes).length})
                           </span>
-                          {expandedVariableAttrs ? (
-                            <ChevronDown className="h-4 w-4 flex-shrink-0" />
-                          ) : (
-                            <ChevronRight className="h-4 w-4 flex-shrink-0" />
-                          )}
+                          {expandedVariableAttrs
+                            ? <ChevronDown className="h-4 w-4 flex-shrink-0" />
+                            : <ChevronRight className="h-4 w-4 flex-shrink-0" />
+                          }
                         </button>
-                        
                         {expandedVariableAttrs && (
                           <div className="max-h-[300px] overflow-y-auto px-3 pb-3 space-y-2 sm:space-y-1 text-xs overflow-x-auto">
-                          {/* <div className="max-h-[300px] overflow-y-auto space-y-1 text-xs overflow-x-auto"> */}
                             {Object.entries(variables[selectedVariable].info.attributes).map(([k, v]) => (
                               <div key={k} className="flex flex-col sm:grid sm:grid-cols-[minmax(100px,auto)_1fr] gap-0.5 sm:gap-2 min-w-0">
                                 <span className="font-mono text-muted-foreground">{k}:</span>
                                 <span className="font-mono break-all pl-4 sm:pl-0">
                                   {typeof v === 'object'
-                                    ? JSON.stringify(v, (_k, val) =>
-                                        typeof val === 'bigint' ? Number(val) : val
-                                      )
+                                    ? JSON.stringify(v, (_k, val) => typeof val === 'bigint' ? Number(val) : val)
                                     : String(v)}
                                 </span>
                               </div>
@@ -965,17 +876,12 @@ const LocalNetCDFMeta = () => {
                     )}
 
                     {/* Load data controls */}
-                    {/* variables[selectedVariable].info.dtype !== 'str' */}
                     {true && (
                       <div className="flex flex-col sm:flex-row gap-2 items-start sm:items-end">
-                        {/* Slice controls - hide for S1 and char */}
-                        {/* !['S1', 'char'].includes(variables[selectedVariable].info.dtype) */}
                         {!['S1', 'char'].includes(variables[selectedVariable].info.dtype) && (
                           <>
                             <div className="w-full sm:w-32">
-                              <Label className="text-xs text-muted-foreground mb-1 block">
-                                Slice size
-                              </Label>
+                              <Label className="text-xs text-muted-foreground mb-1 block">Slice size</Label>
                               <Input
                                 type="number"
                                 min="1"
@@ -1020,7 +926,6 @@ const LocalNetCDFMeta = () => {
                             </div>
                           </>
                         )}
-                        {/* Show only Load All for S1 and char */}
                         {['S1', 'char'].includes(variables[selectedVariable].info.dtype) && (
                           <div className="flex gap-2 items-center">
                             <Button
@@ -1042,6 +947,19 @@ const LocalNetCDFMeta = () => {
                         )}
                       </div>
                     )}
+
+                    {/* ── Slice & Index Tester ── */}
+                    <SliceTesterSection
+                      info={variables[selectedVariable].info}
+                      sliceSelections={sliceSelections}
+                      setSliceSelections={setSliceSelections}
+                      expandedSliceTester={expandedSliceTester}
+                      setExpandedSliceTester={setExpandedSliceTester}
+                      sliceResult={sliceResult}
+                      sliceError={sliceError}
+                      loadingSlice={loadingSlice}
+                      onRun={runSliceTest}
+                    />
                   </div>
                 )}
 
@@ -1060,31 +978,25 @@ const LocalNetCDFMeta = () => {
           {/* Collapsible Dimensions */}
           {Object.keys(dimensions).length > 0 && (
             <Card className="border-0 py-0">
-              <button
-                onClick={() => setExpandedDimensions(!expandedDimensions)}
-                className="w-full"
-              >
+              <button onClick={() => setExpandedDimensions(!expandedDimensions)} className="w-full">
                 <CardHeader className="hover:bg-accent/50 transition-colors cursor-pointer p-2 sm:p-3">
                   <CardTitle className="text-base flex items-center justify-between">
                     <div className="flex items-center gap-2 min-w-0">
                       <Info className="h-4 w-4 flex-shrink-0" />
                       <span className="truncate">Dimensions ({Object.keys(dimensions).length})</span>
                     </div>
-                    {expandedDimensions ? (
-                      <ChevronDown className="h-4 w-4 flex-shrink-0" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4 flex-shrink-0" />
-                    )}
+                    {expandedDimensions
+                      ? <ChevronDown className="h-4 w-4 flex-shrink-0" />
+                      : <ChevronRight className="h-4 w-4 flex-shrink-0" />
+                    }
                   </CardTitle>
                 </CardHeader>
               </button>
-              
               {expandedDimensions && (
                 <CardContent className="p-2 sm:p-3 pt-0">
                   <div className="space-y-1 text-xs overflow-x-auto">
                     {Object.entries(dimensions).map(([name, dim]: [string, any]) => (
                       <div key={name} className="flex flex-col sm:grid sm:grid-cols-[minmax(100px,auto)_1fr] gap-0.5 sm:gap-2 min-w-0">
-                        {/* <div key={k} className="flex flex-col sm:grid sm:grid-cols-[minmax(100px,auto)_1fr] gap-0.5 sm:gap-2 min-w-0"> */}
                         <span className="font-mono text-muted-foreground">{name}:</span>
                         <span className="font-mono break-all pl-4 sm:pl-0">
                           {dim.size || dim.len || dim.length || 'unlimited'}
@@ -1100,25 +1012,20 @@ const LocalNetCDFMeta = () => {
           {/* Collapsible Attributes */}
           {Object.keys(attributes).length > 0 && (
             <Card className="border-0 py-0">
-              <button
-                onClick={() => setExpandedAttributes(!expandedAttributes)}
-                className="w-full"
-              >
+              <button onClick={() => setExpandedAttributes(!expandedAttributes)} className="w-full">
                 <CardHeader className="hover:bg-accent/50 transition-colors cursor-pointer p-2 sm:p-3">
                   <CardTitle className="text-base flex items-center justify-between">
                     <div className="flex items-center gap-2 min-w-0">
                       <Info className="h-4 w-4 flex-shrink-0" />
                       <span className="truncate">Attributes ({Object.keys(attributes).length})</span>
                     </div>
-                    {expandedAttributes ? (
-                      <ChevronDown className="h-4 w-4 flex-shrink-0" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4 flex-shrink-0" />
-                    )}
+                    {expandedAttributes
+                      ? <ChevronDown className="h-4 w-4 flex-shrink-0" />
+                      : <ChevronRight className="h-4 w-4 flex-shrink-0" />
+                    }
                   </CardTitle>
                 </CardHeader>
               </button>
-              
               {expandedAttributes && (
                 <CardContent className="p-2 sm:p-3 pt-0">
                   <div className="max-h-[300px] overflow-y-auto space-y-1 text-xs overflow-x-auto">
@@ -1127,9 +1034,7 @@ const LocalNetCDFMeta = () => {
                         <span className="font-mono text-muted-foreground break-words">{k}:</span>
                         <span className="font-mono break-all pl-4 sm:pl-0">
                           {typeof v === 'object'
-                            ? JSON.stringify(v, (_k, val) =>
-                                typeof val === 'bigint' ? Number(val) : val
-                              )
+                            ? JSON.stringify(v, (_k, val) => typeof val === 'bigint' ? Number(val) : val)
                             : String(v)}
                         </span>
                       </div>

--- a/docs/next-js/components/loading/SliceTester.tsx
+++ b/docs/next-js/components/loading/SliceTester.tsx
@@ -1,0 +1,271 @@
+'use client';
+import React from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Terminal, ChevronRight, ChevronDown } from 'lucide-react';
+import { slice as ncSlice } from '@earthyscience/netcdf4-wasm';
+
+// Types
+export type SelectionMode = 'all' | 'scalar' | 'slice';
+
+export interface SliceSelectionState {
+  mode:   SelectionMode;
+  scalar: string;
+  start:  string;
+  stop:   string;
+  step:   string;
+}
+
+export function defaultSelection(): SliceSelectionState {
+  return { mode: 'all', scalar: '0', start: '0', stop: '', step: '1' };
+}
+
+// buildSelection — converts UI state → DimSelection[] for dataset.get()
+
+export function buildSelection(
+  sels: SliceSelectionState[],
+  shape: Array<number | bigint>
+): Array<null | number | ReturnType<typeof ncSlice>> {
+
+  return sels.map((s, i) => {
+    const dimSize = Number(shape[i]);
+
+    // ALL
+    if (s.mode === 'all') {
+      return ncSlice(0, dimSize, 1);
+    }
+
+    // SCALAR
+    if (s.mode === 'scalar') {
+      let idx = parseInt(s.scalar);
+
+      if (Number.isNaN(idx)) idx = 0;
+
+      // normalize negative indices
+      if (idx < 0) idx = dimSize + idx;
+
+      if (idx < 0 || idx >= dimSize) {
+        throw new Error(`index ${idx} out of bounds for dim ${i} size ${dimSize}`);
+      }
+
+      return idx;
+    }
+
+    // SLICE
+    let start = s.start !== '' ? parseInt(s.start) : 0;
+    let stop  = s.stop  !== '' ? parseInt(s.stop)  : dimSize;
+    let step  = s.step  !== '' ? parseInt(s.step)  : 1;
+
+    if (Number.isNaN(start)) start = 0;
+    if (Number.isNaN(stop))  stop  = dimSize;
+    if (Number.isNaN(step))  step  = 1;
+
+    // normalize negatives
+    if (start < 0) start = dimSize + start;
+    if (stop  < 0) stop  = dimSize + stop;
+
+    return ncSlice(start, stop, step);
+  });
+}
+
+// SliceTesterSection component
+
+interface SliceTesterSectionProps {
+  info:                    any;
+  sliceSelections:         SliceSelectionState[];
+  setSliceSelections:      React.Dispatch<React.SetStateAction<SliceSelectionState[]>>;
+  expandedSliceTester:     boolean;
+  setExpandedSliceTester:  (v: boolean) => void;
+  sliceResult:             any;
+  sliceError:              string | null;
+  loadingSlice:            boolean;
+  onRun:                   () => void;
+}
+
+const SliceTesterSection: React.FC<SliceTesterSectionProps> = ({
+  info,
+  sliceSelections,
+  setSliceSelections,
+  expandedSliceTester,
+  setExpandedSliceTester,
+  sliceResult,
+  sliceError,
+  loadingSlice,
+  onRun,
+}) => {
+  if (!info?.shape || info.shape.length === 0) return null;
+
+  // Coerce shape to plain numbers — nc_inq_dimlen uses i64 so values may be BigInt
+  const shape: number[] = (info.shape as any[]).map(Number);
+
+  const updateSel = (i: number, patch: Partial<SliceSelectionState>) =>
+    setSliceSelections(prev => prev.map((s, idx) => idx === i ? { ...s, ...patch } : s));
+
+  const resultPreview = sliceResult
+    ? (() => {
+        const arr = Array.isArray(sliceResult) ? sliceResult : Array.from(sliceResult as any);
+        const items = (arr as any[]).slice(0, 30).map((v: any) =>
+          typeof v === 'number' ? v.toFixed(4) : String(v)
+        );
+        const suffix = arr.length > 30 ? `, … (${arr.length} total)` : '';
+        return `[${items.join(', ')}${suffix}]`;
+      })()
+    : null;
+
+  const selectionPreview = sliceSelections.map((s, i) => {
+    if (s.mode === 'all') return 'null';
+    if (s.mode === 'scalar') return s.scalar || '0';
+    const parts: string[] = [s.start || '0', s.stop || String(shape[i])];
+    if (s.step && s.step !== '1') parts.push(s.step);
+    return `slice(${parts.join(', ')})`;
+  }).join(', ');
+
+  return (
+    <div className="border-[0.1px] rounded-lg overflow-hidden mt-2">
+      {/* Header */}
+      <button
+        onClick={() => setExpandedSliceTester(!expandedSliceTester)}
+        className="w-full flex items-center justify-between p-3 hover:bg-accent/50 transition-colors cursor-pointer"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold">Slice &amp; Index Tester</span>
+          <span className="text-xs text-muted-foreground font-mono">
+            shape: [{shape.join(', ')}]
+          </span>
+        </div>
+        {expandedSliceTester
+          ? <ChevronDown  className="h-4 w-4 flex-shrink-0" />
+          : <ChevronRight className="h-4 w-4 flex-shrink-0" />
+        }
+      </button>
+
+      {expandedSliceTester && (
+        <div className="px-3 pb-3 space-y-3">
+
+          {/* Dimension rows */}
+          <div className="space-y-2">
+            {shape.map((dimSize: number, i: number) => {
+              const dimName = info.dimensions?.[i] ?? `dim_${i}`;
+              const sel = sliceSelections[i] ?? defaultSelection();
+
+              return (
+                <div key={i} className="border rounded-md p-2 space-y-2 bg-muted/30">
+                  {/* Label + mode tabs */}
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-mono text-xs text-muted-foreground w-24 shrink-0 truncate">
+                      {dimName}
+                      <span className="text-muted-foreground/60"> [{dimSize}]</span>
+                    </span>
+                    <div className="flex rounded-md border overflow-hidden text-xs">
+                      {(['all', 'scalar', 'slice'] as SelectionMode[]).map(m => (
+                        <button
+                          key={m}
+                          onClick={() => updateSel(i, { mode: m })}
+                          className={`px-2 py-1 transition-colors ${
+                            sel.mode === m
+                              ? 'bg-primary text-primary-foreground font-semibold'
+                              : 'hover:bg-accent/50'
+                          }`}
+                        >
+                          {m === 'all' ? 'null' : m}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Scalar input */}
+                  {sel.mode === 'scalar' && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground w-10">index</span>
+                      <Input
+                        type="number"
+                        min={-dimSize}
+                        max={dimSize - 1}
+                        value={sel.scalar}
+                        onChange={e => updateSel(i, { scalar: e.target.value })}
+                        className="h-7 text-xs w-28 font-mono"
+                        placeholder="0"
+                      />
+                      <span className="text-xs text-muted-foreground">
+                        (0 … {dimSize - 1}, or negative)
+                      </span>
+                    </div>
+                  )}
+
+                  {/* Slice inputs */}
+                  {sel.mode === 'slice' && (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      {[
+                        { label: 'start', key: 'start' as const, placeholder: '0' },
+                        { label: 'stop',  key: 'stop'  as const, placeholder: String(dimSize) },
+                        { label: 'step',  key: 'step'  as const, placeholder: '1' },
+                      ].map(({ label, key, placeholder }) => (
+                        <div key={key} className="flex items-center gap-1">
+                          <span className="text-xs text-muted-foreground w-8">{label}</span>
+                          <Input
+                            type="number"
+                            value={sel[key]}
+                            onChange={e => updateSel(i, { [key]: e.target.value })}
+                            className="h-7 text-xs w-20 font-mono"
+                            placeholder={placeholder}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Selection preview */}
+          <div className="text-xs font-mono text-muted-foreground bg-muted/50 rounded px-2 py-1.5 break-all">
+            get("{info.name}", [{selectionPreview}])
+          </div>
+
+          {/* Run + result count */}
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              onClick={onRun}
+              disabled={loadingSlice}
+              style={{ backgroundColor: '#644FF0', color: 'white' }}
+              className="flex-shrink-0"
+            >
+              {loadingSlice ? (
+                <><Spinner className="h-3 w-3 mr-2" />Running…</>
+              ) : 'Run'}
+            </Button>
+            {sliceResult && (
+              <span className="text-xs text-muted-foreground">
+                {(() => {
+                  const arr = Array.isArray(sliceResult) ? sliceResult : Array.from(sliceResult as any);
+                  return `${arr.length} elements`;
+                })()}
+              </span>
+            )}
+          </div>
+
+          {/* Error */}
+          {sliceError && (
+            <Alert variant="destructive" className="py-2">
+              <Terminal className="h-4 w-4 flex-shrink-0" />
+              <AlertDescription className="text-xs break-words">{sliceError}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* Result preview */}
+          {resultPreview && (
+            <pre className="bg-muted p-2 rounded font-mono text-xs overflow-x-auto whitespace-pre-wrap break-all">
+              {resultPreview}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SliceTesterSection;

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -964,6 +964,91 @@ int nc_get_var_ulonglong_wrapper(int ncid, int varid, unsigned long long* value)
 }
 
 // =========================
+// Strided Data Access (nc_get_vars_*)
+// Add these alongside your existing nc_get_vara_*_wrapper functions
+// =========================
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_schar_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, signed char* value) {
+    return nc_get_vars_schar(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_uchar_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, unsigned char* value) {
+    return nc_get_vars_uchar(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_short_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, short* value) {
+    return nc_get_vars_short(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_ushort_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, unsigned short* value) {
+    return nc_get_vars_ushort(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_int_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, int* value) {
+    return nc_get_vars_int(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_uint_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, unsigned int* value) {
+    return nc_get_vars_uint(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_float_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, float* value) {
+    return nc_get_vars_float(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_double_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, double* value) {
+    return nc_get_vars_double(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_longlong_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, long long* value) {
+    return nc_get_vars_longlong(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_ulonglong_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, unsigned long long* value) {
+    return nc_get_vars_ulonglong(ncid, varid, start, count, stride, value);
+}
+
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_string_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, char** value) {
+    return nc_get_vars_string(ncid, varid, start, count, stride, value);
+}
+
+// Generic strided wrapper — mirrors your existing nc_get_vara_wrapper
+// Uses nc_get_vars which accepts void* output and nc_type for dispatch
+EMSCRIPTEN_KEEPALIVE
+int nc_get_vars_wrapper(int ncid, int varid, const size_t* start, const size_t* count, const ptrdiff_t* stride, void* value) {
+    // nc_get_vars_* requires knowing the type — use nc_get_vara with the generic
+    // approach by getting the variable type first and dispatching
+    nc_type xtype;
+    int stat = nc_inq_vartype(ncid, varid, &xtype);
+    if (stat != NC_NOERR) return stat;
+
+    switch (xtype) {
+        case NC_BYTE:     return nc_get_vars_schar(ncid, varid, start, count, stride, (signed char*)value);
+        case NC_UBYTE:    return nc_get_vars_uchar(ncid, varid, start, count, stride, (unsigned char*)value);
+        case NC_SHORT:    return nc_get_vars_short(ncid, varid, start, count, stride, (short*)value);
+        case NC_USHORT:   return nc_get_vars_ushort(ncid, varid, start, count, stride, (unsigned short*)value);
+        case NC_INT:      return nc_get_vars_int(ncid, varid, start, count, stride, (int*)value);
+        case NC_UINT:     return nc_get_vars_uint(ncid, varid, start, count, stride, (unsigned int*)value);
+        case NC_FLOAT:    return nc_get_vars_float(ncid, varid, start, count, stride, (float*)value);
+        case NC_DOUBLE:   return nc_get_vars_double(ncid, varid, start, count, stride, (double*)value);
+        case NC_INT64:    return nc_get_vars_longlong(ncid, varid, start, count, stride, (long long*)value);
+        case NC_UINT64:   return nc_get_vars_ulonglong(ncid, varid, start, count, stride, (unsigned long long*)value);
+        default:          return NC_EBADTYPE;
+    }
+}
+
+// =========================
 // Data Writing
 // =========================
 EMSCRIPTEN_KEEPALIVE

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
 
 // Export all classes and types
 export { NetCDF4, DataTree } from './netcdf4.js';
+export { slice, Slice } from './slice.js';
+export type { DimSelection, ResolvedDim } from './slice.js';
 export type { GroupNode } from './netcdf4.js';
 export { Variable } from './variable.js';
 export { Dimension } from './dimension.js';

--- a/src/netcdf-getters.ts
+++ b/src/netcdf-getters.ts
@@ -1,5 +1,6 @@
 import { NC_CONSTANTS, DATA_TYPE_SIZE, CONSTANT_DTYPE_MAP } from './constants.js';
 import type { NetCDF4Module } from './types.js';
+import { DimSelection, ResolvedDim, resolveDim } from "./slice.js";
 
 export function getGroupVariables(
     module: NetCDF4Module,
@@ -643,6 +644,201 @@ export function getSlicedVariableArray(
     }
 
     return arrayData.data;
+}
+
+type AnyTypedArray =
+    | Int8Array    | Uint8Array
+    | Int16Array   | Uint16Array
+    | Int32Array   | Uint32Array
+    | Float32Array | Float64Array
+    | BigInt64Array | BigUint64Array
+    | string[];
+
+export function getVariableArrayWithSelection(
+    module: NetCDF4Module,
+    ncid: number,
+    variable: number | string,
+    selection: DimSelection[],
+    groupPath?: string,
+    options?: { convertEnumsToNames?: boolean }
+): AnyTypedArray {
+    const workingNcid = groupPath ? getGroupNCID(module, ncid, groupPath) : ncid;
+
+    // Resolve varid
+    let varid: number;
+    if (typeof variable === "number") {
+        varid = variable;
+    } else {
+        const r = module.nc_inq_varid(workingNcid, variable);
+        if (r.result !== NC_CONSTANTS.NC_NOERR) {
+            throw new Error(`Failed to get variable id for '${variable}' (error: ${r.result})`);
+        }
+        varid = r.varid as number;
+    }
+
+    // Query variable dimensions — use workingNcid throughout
+    const varInfo = module.nc_inq_var(workingNcid, varid);
+    if (varInfo.result !== NC_CONSTANTS.NC_NOERR) {
+        throw new Error(`Failed to query variable info (error: ${varInfo.result})`);
+    }
+
+    const dimids: number[] = Array.from(varInfo.dimids ?? []);
+    const ndim = dimids.length;
+
+    if (selection.length !== ndim) {
+        throw new Error(
+            `Selection has ${selection.length} dimension(s) but variable has ${ndim}`
+        );
+    }
+
+    // Fetch each dimension's size — resolveDim handles BigInt safely
+    const dimSizes = dimids.map((dimid: number) => {
+        const r = module.nc_inq_dimlen(workingNcid, dimid);
+        if (r.result !== NC_CONSTANTS.NC_NOERR) {
+            throw new Error(`Failed to query dim length for dimid ${dimid} (error: ${r.result})`);
+        }
+        return r.len as number | bigint;
+    });
+
+    // Resolve each selection — resolveDim coerces BigInt internally
+    const resolved: ResolvedDim[] = selection.map((sel, i) =>
+        resolveDim(sel, dimSizes[i])
+    );
+
+    const start  = resolved.map(d => d.start);
+    const count  = resolved.map(d => d.count);
+    const stride = resolved.map(d => Math.abs(d.step));
+
+    const useStride       = stride.some(s => s !== 1);
+    const hasNegativeStep = resolved.some(d => d.step < 0);
+
+    // Resolve variable type — use workingNcid so enum lookup is in the right group
+    const { enumCtx } = resolveVariableType(module, workingNcid, varid);
+    const arrayType = enumCtx.baseType;
+
+    let arrayData: { result: number; data?: any };
+
+    // ── Read data ─────────────────────────────────────────────────────────────
+    // All reads go directly through workingNcid + varid — no group re-resolution.
+
+    if (enumCtx.isEnum) {
+        if (useStride) {
+            arrayData = module.nc_get_vars_generic(workingNcid, varid, start, count, stride, arrayType);
+        } else {
+            arrayData = module.nc_get_vara_generic(workingNcid, varid, start, count, arrayType);
+        }
+    } else if (useStride) {
+        type VarsArgs = [number, number, number[], number[], number[]];
+        type VarsResult = { result: number; data?: any };
+
+        const stridedReaders: Record<number, (...args: VarsArgs) => VarsResult> = {
+            [NC_CONSTANTS.NC_BYTE]:      (...args) => module.nc_get_vars_schar(...args),
+            [NC_CONSTANTS.NC_UBYTE]:     (...args) => module.nc_get_vars_uchar(...args),
+            [NC_CONSTANTS.NC_SHORT]:     (...args) => module.nc_get_vars_short(...args),
+            [NC_CONSTANTS.NC_USHORT]:    (...args) => module.nc_get_vars_ushort(...args),
+            [NC_CONSTANTS.NC_INT]:       (...args) => module.nc_get_vars_int(...args),
+            [NC_CONSTANTS.NC_UINT]:      (...args) => module.nc_get_vars_uint(...args),
+            [NC_CONSTANTS.NC_FLOAT]:     (...args) => module.nc_get_vars_float(...args),
+            [NC_CONSTANTS.NC_DOUBLE]:    (...args) => module.nc_get_vars_double(...args),
+            [NC_CONSTANTS.NC_INT64]:     (...args) => module.nc_get_vars_longlong(...args),
+            [NC_CONSTANTS.NC_LONGLONG]:  (...args) => module.nc_get_vars_longlong(...args),
+            [NC_CONSTANTS.NC_UINT64]:    (...args) => module.nc_get_vars_ulonglong(...args),
+            [NC_CONSTANTS.NC_ULONGLONG]: (...args) => module.nc_get_vars_ulonglong(...args),
+            [NC_CONSTANTS.NC_STRING]:    (...args) => module.nc_get_vars_string(...args),
+        };
+
+        const reader = stridedReaders[arrayType];
+        if (!reader) {
+            console.warn(`Unknown NetCDF type ${arrayType} for strided read, falling back to double`);
+            arrayData = module.nc_get_vars_double(workingNcid, varid, start, count, stride);
+        } else {
+            arrayData = reader(workingNcid, varid, start, count, stride);
+        }
+    } else {
+        type VaraArgs = [number, number, number[], number[]];
+        type VaraResult = { result: number; data?: any };
+
+        const readers: Record<number, (...args: VaraArgs) => VaraResult> = {
+            [NC_CONSTANTS.NC_BYTE]:      (...args) => module.nc_get_vara_schar(...args),
+            [NC_CONSTANTS.NC_UBYTE]:     (...args) => module.nc_get_vara_uchar(...args),
+            [NC_CONSTANTS.NC_SHORT]:     (...args) => module.nc_get_vara_short(...args),
+            [NC_CONSTANTS.NC_USHORT]:    (...args) => module.nc_get_vara_ushort(...args),
+            [NC_CONSTANTS.NC_INT]:       (...args) => module.nc_get_vara_int(...args),
+            [NC_CONSTANTS.NC_UINT]:      (...args) => module.nc_get_vara_uint(...args),
+            [NC_CONSTANTS.NC_FLOAT]:     (...args) => module.nc_get_vara_float(...args),
+            [NC_CONSTANTS.NC_DOUBLE]:    (...args) => module.nc_get_vara_double(...args),
+            [NC_CONSTANTS.NC_INT64]:     (...args) => module.nc_get_vara_longlong(...args),
+            [NC_CONSTANTS.NC_LONGLONG]:  (...args) => module.nc_get_vara_longlong(...args),
+            [NC_CONSTANTS.NC_UINT64]:    (...args) => module.nc_get_vara_ulonglong(...args),
+            [NC_CONSTANTS.NC_ULONGLONG]: (...args) => module.nc_get_vara_ulonglong(...args),
+            [NC_CONSTANTS.NC_STRING]:    (...args) => module.nc_get_vara_string(...args),
+        };
+
+        const reader = readers[arrayType];
+        if (!reader) {
+            console.warn(`Unknown NetCDF type ${arrayType}, falling back to double`);
+            arrayData = module.nc_get_vara_double(workingNcid, varid, start, count);
+        } else {
+            arrayData = reader(workingNcid, varid, start, count);
+        }
+    }
+
+    if (arrayData.result !== NC_CONSTANTS.NC_NOERR) {
+        throw new Error(`Failed to read array data (error: ${arrayData.result})`);
+    }
+    if (!arrayData.data) {
+        throw new Error("nc_get_vara/vars returned no data");
+    }
+
+    let result: AnyTypedArray = arrayData.data;
+
+    if (enumCtx.isEnum && options?.convertEnumsToNames && enumCtx.enumDict) {
+        result = convertEnumValuesToNames(result, enumCtx.enumDict);
+    }
+
+    // Reverse dimensions that had a negative step — cheap, operates on already-small output
+    if (hasNegativeStep) {
+        result = applyNegativeStepReversal(result, resolved);
+    }
+
+    return result;
+}
+
+// applyNegativeStepReversal
+
+function applyNegativeStepReversal<T extends AnyTypedArray>(
+    data: T,
+    resolved: ResolvedDim[]
+): T {
+    const ndim = resolved.length;
+    const outCount = resolved.map(d =>
+        d.collapsed ? 1 : Math.ceil(d.count / Math.abs(d.step))
+    );
+    const totalOut = outCount.reduce((a, b) => a * b, 1);
+
+    const outStrides = new Array<number>(ndim);
+    outStrides[ndim - 1] = 1;
+    for (let i = ndim - 2; i >= 0; i--) {
+        outStrides[i] = outStrides[i + 1] * outCount[i + 1];
+    }
+
+    const out: AnyTypedArray = Array.isArray(data)
+        ? new Array<string>(totalOut)
+        : new (data.constructor as any)(totalOut);
+
+    for (let outIdx = 0; outIdx < totalOut; outIdx++) {
+        let rem    = outIdx;
+        let srcIdx = 0;
+        for (let d = 0; d < ndim; d++) {
+            const logI = Math.floor(rem / outStrides[d]);
+            rem -= logI * outStrides[d];
+            const srcI = resolved[d].step < 0 ? outCount[d] - 1 - logI : logI;
+            srcIdx += srcI * outStrides[d];
+        }
+        (out as any)[outIdx] = (data as any)[srcIdx];
+    }
+
+    return out as T;
 }
 
 //---- Group Functions ----//

--- a/src/netcdf-worker.ts
+++ b/src/netcdf-worker.ts
@@ -136,6 +136,17 @@ self.onmessage = async (e: MessageEvent) => {
                 result = NCGet.getAttributeValues(mod, data.ncid, data.varid, data.attname);
                 break;
 
+            case 'getVariableArrayWithSelection':
+                result = NCGet.getVariableArrayWithSelection(
+                    mod,
+                    data.ncid,
+                    data.variable,
+                    data.selection,
+                    data.groupPath,
+                    data.options
+                );
+                break;
+
             // ---- Arrays ----
             case 'getVariableArray':
                 result = NCGet.getVariableArray(mod, data.ncid, data.variable, data.groupPath);

--- a/src/netcdf4.ts
+++ b/src/netcdf4.ts
@@ -5,6 +5,7 @@ import { WasmModuleLoader } from './wasm-module.js';
 import { NC_CONSTANTS } from './constants.js';
 import type { NetCDF4Module, DatasetOptions, MemoryDatasetSource } from './types.js';
 import * as NCGet from './netcdf-getters.js'
+import { DimSelection } from './slice.js';
 
 export class NetCDF4 extends Group {
     private module: NetCDF4Module | null = null;
@@ -441,6 +442,62 @@ export class NetCDF4 extends Group {
         } else {
             // Main thread path is already synchronous (or could be wrapped in Promise.resolve)
             return NCGet.getSlicedVariableArray(this.module as NetCDF4Module, this.ncid, variable, start, count, groupPath);
+        }
+    }
+
+    /**
+     * slicing and indexing convenience method.
+     *
+     * Each element of `selection` corresponds to one dimension of the variable:
+     *   - `null`                     → all elements of that dimension
+     *   - `number`                   → scalar index (dimension is collapsed)
+     *   - `slice(stop)`              → elements [0, stop)
+     *   - `slice(start, stop)`       → elements [start, stop)
+     *   - `slice(start, stop, step)` → strided subset; step may be negative
+     *
+     * Strided reads use nc_get_vars_* under the hood.
+     * Negative step reads forward then reverses the affected dimension.
+     * Returns a flat typed array; caller infers shape from non-collapsed dims.
+     *
+     * @example
+     * // Variable shape [time, lat, lon]
+     * // Read 10 time steps, all lats, first lon:
+     * const data = await arr.get("temperature", [slice(0, 10), null, 0]);
+     *
+     * @example
+     * // Every other element along time:
+     * const data = await arr.get("temperature", [slice(0, 100, 2), null, null]);
+     *
+     * @example
+     * // Reversed time axis:
+     * const data = await arr.get("temperature", [slice(null, null, -1), null, null]);
+     */
+    async get(
+        variable: number | string,
+        selection: DimSelection[],
+        groupPath?: string,
+        options?: { convertEnumsToNames?: boolean }
+    ): Promise<
+        Int8Array    | Uint8Array   |
+        Int16Array   | Uint16Array  |
+        Int32Array   | Uint32Array  |
+        Float32Array | Float64Array |
+        BigInt64Array | BigUint64Array |
+        string[]
+    > {
+        if (this.worker) {
+            return this.callWorker('getVariableArrayWithSelection', {
+                ncid: this.ncid, variable, selection, groupPath, options
+            });
+        } else {
+            return NCGet.getVariableArrayWithSelection(
+                this.module as NetCDF4Module,
+                this.ncid,
+                variable,
+                selection,
+                groupPath,
+                options
+            );
         }
     }
 

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -1,0 +1,94 @@
+/**
+ * Represents a dimension slice.
+ * Null fields are resolved against the actual dimension size at read time.
+ */
+export class Slice {
+    constructor(
+        public readonly start: number | null,
+        public readonly stop:  number | null,
+        public readonly step:  number | null
+    ) {}
+}
+
+/**
+ * slice(stop)
+ * slice(start, stop)
+ * slice(start, stop, step)
+ * slice(null) — equivalent to null (all elements)
+ */
+export function slice(stop: number | null): Slice;
+export function slice(start: number | null, stop: number | null): Slice;
+export function slice(start: number | null, stop: number | null, step: number | null): Slice;
+export function slice(
+    startOrStop: number | null,
+    stop?: number | null,
+    step?: number | null
+): Slice {
+    if (stop === undefined) {
+        return new Slice(null, startOrStop, null);
+    }
+    return new Slice(startOrStop, stop ?? null, step ?? null);
+}
+
+/** A single dimension selection: null = all, number = scalar index, Slice = range */
+export type DimSelection = null | number | Slice;
+
+/**
+ * Resolved, concrete read parameters for one dimension after applying a
+ * DimSelection against a known dimension size.
+ */
+export interface ResolvedDim {
+    /** Start index in the NetCDF dimension (always the lower bound, even for negative step) */
+    start: number;
+    /** Number of elements to read from NetCDF (contiguous span, always positive) */
+    count: number;
+    /** Step. Positive = forward, negative = reversed output. Never 0. */
+    step: number;
+    /** True when the selection was a scalar index — dimension is collapsed */
+    collapsed: boolean;
+}
+
+/**
+ * Resolve a DimSelection against a concrete dimension size.
+ * Accepts BigInt dimension sizes (from nc_inq_dimlen i64 reads) and coerces safely.
+ */
+export function resolveDim(sel: DimSelection, dimSizeRaw: number | bigint): ResolvedDim {
+    // Coerce up front — nc_inq_dimlen returns i64 so dimSize may arrive as BigInt
+    const dimSize = Number(dimSizeRaw);
+
+    // null or empty Slice → full dimension
+    if (
+        sel === null ||
+        (sel instanceof Slice && sel.start === null && sel.stop === null && sel.step === null)
+    ) {
+        return { start: 0, count: dimSize, step: 1, collapsed: false };
+    }
+
+    // Scalar index → collapsed dimension
+    if (typeof sel === "number") {
+        const idx     = sel < 0 ? dimSize + sel : sel;
+        const clamped = Math.max(0, Math.min(idx, dimSize - 1));
+        return { start: clamped, count: 1, step: 1, collapsed: true };
+    }
+
+    // Slice
+    const step = sel.step ?? 1;
+    if (step === 0) throw new Error("Slice step cannot be zero");
+
+    if (step > 0) {
+        const rawStart = sel.start ?? 0;
+        const rawStop  = sel.stop  ?? dimSize;
+        const start    = Math.max(0, Math.min(rawStart < 0 ? dimSize + rawStart : rawStart, dimSize));
+        const stop     = Math.max(0, Math.min(rawStop  < 0 ? dimSize + rawStop  : rawStop,  dimSize));
+        const count    = Math.max(0, stop - start);
+        return { start, count, step, collapsed: false };
+    } else {
+        // Negative step: read [stop+1 .. start] forward from NetCDF, reverse client-side
+        const rawStart = sel.start ?? dimSize - 1;
+        const rawStop  = sel.stop  ?? -1;
+        const start    = Math.max(0,  Math.min(rawStart < 0 ? dimSize + rawStart : rawStart, dimSize - 1));
+        const stop     = Math.max(-1, Math.min(rawStop  < 0 ? dimSize + rawStop  : rawStop,  dimSize - 1));
+        const count    = Math.max(0, start - stop);
+        return { start: stop + 1, count, step, collapsed: false };
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,22 @@ export interface NetCDF4Module extends EmscriptenModule {
     nc_get_vara_ulonglong: (ncid: number, varid: number, startp: number[], countp: number[]) => { result: number; data?: BigUint64Array };
     nc_get_vara_string: (ncid: number, varid: number, startp: number[], countp: number[]) => { result: number; data?: string[] };
 
+
+    // Strided Variable Getters (nc_get_vars_*)
+    // stride[i] = step along dimension i (must be >= 1; negatives handled at higher level)
+    nc_get_vars_schar:     (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: Int8Array };
+    nc_get_vars_uchar:     (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: Uint8Array };
+    nc_get_vars_short:     (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: Int16Array };
+    nc_get_vars_ushort:    (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: Uint16Array };
+    nc_get_vars_int:       (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: Int32Array };
+    nc_get_vars_uint:      (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: Uint32Array };
+    nc_get_vars_float:     (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: Float32Array };
+    nc_get_vars_double:    (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: Float64Array };
+    nc_get_vars_longlong:  (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: BigInt64Array };
+    nc_get_vars_ulonglong: (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: BigUint64Array };
+    nc_get_vars_string:    (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[]) => { result: number; data?: string[] };
+    nc_get_vars_generic:   (ncid: number, varid: number, startp: number[], countp: number[], stridep: number[], nctype: number) => { result: number; data?: Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | BigInt64Array | BigUint64Array };
+
     // group types and functions
     nc_inq_grps: (ncid: number) => { result: number; numgrps?: number; grpids?: Int32Array };
     nc_inq_grp_ncid: (ncid: number, grp_name: string) => { result: number; grp_ncid?: number };

--- a/src/wasm-module.ts
+++ b/src/wasm-module.ts
@@ -7,6 +7,10 @@ const NC_MAX_NAME = 256;
 const NC_MAX_DIMS = 1024;  
 const NC_MAX_VARS = 8192;
 
+function stridedLength(count: number[], stride: number[]): number {
+    return count.reduce((acc, c, i) => acc * Math.ceil(c / stride[i]), 1);
+}
+
 export class WasmModuleLoader {
     static async loadModule(options: NetCDF4WasmOptions = {}): Promise<NetCDF4Module> {
         try {            
@@ -129,6 +133,21 @@ export class WasmModuleLoader {
         const nc_get_var_uint_wrapper = module.cwrap('nc_get_var_uint_wrapper', 'number', ['number', 'number', 'number']);
         const nc_get_var_ulonglong_wrapper = module.cwrap('nc_get_var_ulonglong_wrapper', 'number', ['number', 'number', 'number']);
         const nc_get_var_string_wrapper = module.cwrap('nc_get_var_string_wrapper', 'number', ['number', 'number', 'number']);
+
+        // Stride inquiry wrappers
+
+        const nc_get_vars_schar_wrapper     = module.cwrap('nc_get_vars_schar_wrapper',     'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_uchar_wrapper     = module.cwrap('nc_get_vars_uchar_wrapper',     'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_short_wrapper     = module.cwrap('nc_get_vars_short_wrapper',     'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_ushort_wrapper    = module.cwrap('nc_get_vars_ushort_wrapper',    'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_int_wrapper       = module.cwrap('nc_get_vars_int_wrapper',       'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_uint_wrapper      = module.cwrap('nc_get_vars_uint_wrapper',      'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_float_wrapper     = module.cwrap('nc_get_vars_float_wrapper',     'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_double_wrapper    = module.cwrap('nc_get_vars_double_wrapper',    'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_longlong_wrapper  = module.cwrap('nc_get_vars_longlong_wrapper',  'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_ulonglong_wrapper = module.cwrap('nc_get_vars_ulonglong_wrapper', 'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_string_wrapper    = module.cwrap('nc_get_vars_string_wrapper',    'number', ['number','number','number','number','number','number']);
+        const nc_get_vars_wrapper           = module.cwrap('nc_get_vars_wrapper',           'number', ['number','number','number','number','number','number']);
 
 
         // Group inquiry wrappers
@@ -1292,6 +1311,230 @@ export class WasmModuleLoader {
                 module._free(dataPtr);
                 module._free(startPtr);
                 module._free(countPtr);
+                return { result, data };
+            },
+
+            // start/count/stride → i64 / 8 bytes per element  (matching nc_get_vara_double etc.)
+
+            nc_get_vars_schar: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 1);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_schar_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new Int8Array(module.HEAP8.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_uchar: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 1);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_uchar_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new Uint8Array(module.HEAPU8.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_short: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 2);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_short_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new Int16Array(module.HEAP16.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_ushort: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 2);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_ushort_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new Uint16Array(module.HEAPU16.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_int: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 4);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_int_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new Int32Array(module.HEAP32.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_uint: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 4);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_uint_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new Uint32Array(module.HEAPU32.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_float: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 4);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_float_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new Float32Array(module.HEAPF32.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_double: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 8);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_double_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new Float64Array(module.HEAPF64.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_longlong: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 8);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_longlong_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new BigInt64Array(module.HEAP64.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_ulonglong: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 8);
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_ulonglong_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                const data = result === NC_CONSTANTS.NC_NOERR
+                    ? new BigUint64Array(module.HEAPU64.buffer, dataPtr, totalLength).slice()
+                    : undefined;
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            nc_get_vars_string: (ncid: number, varid: number, start: number[], count: number[], stride: number[]) => {
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * 4); // char* pointers (4 bytes in wasm32)
+                const startPtr  = module._malloc(start.length * 8);
+                const countPtr  = module._malloc(count.length * 8);
+                const stridePtr = module._malloc(stride.length * 8);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 8, v, 'i64'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 8, v, 'i64'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 8, v, 'i64'));
+                const result = nc_get_vars_string_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                let data: string[] | undefined;
+                if (result === NC_CONSTANTS.NC_NOERR) {
+                    data = [];
+                    for (let i = 0; i < totalLength; i++) {
+                        const strPtr = module.getValue(dataPtr + i * 4, '*');
+                        data.push(module.UTF8ToString(strPtr));
+                    }
+                }
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
+                return { result, data };
+            },
+
+            // Generic strided reader — mirrors nc_get_vara_generic but with stride.
+            // Uses i32 for start/count/stride to match nc_get_vara_generic's convention, should it be i64?
+            nc_get_vars_generic: (ncid: number, varid: number, start: number[], count: number[], stride: number[], nctype: number) => {
+                const elementSize = DATA_TYPE_SIZE[nctype];
+                const totalLength = stridedLength(count, stride);
+                const dataPtr   = module._malloc(totalLength * elementSize);
+                const startPtr  = module._malloc(start.length * 4);
+                const countPtr  = module._malloc(count.length * 4);
+                const stridePtr = module._malloc(stride.length * 4);
+                start .forEach((v, i) => module.setValue(startPtr  + i * 4, v, 'i32'));
+                count .forEach((v, i) => module.setValue(countPtr  + i * 4, v, 'i32'));
+                stride.forEach((v, i) => module.setValue(stridePtr + i * 4, v, 'i32'));
+                const result = nc_get_vars_wrapper(ncid, varid, startPtr, countPtr, stridePtr, dataPtr);
+                let data;
+                if (result === NC_CONSTANTS.NC_NOERR) {
+                    switch (nctype) {
+                        case NC_CONSTANTS.NC_BYTE:   data = new Int8Array(module.HEAP8.buffer,     dataPtr, totalLength).slice(); break;
+                        case NC_CONSTANTS.NC_UBYTE:  data = new Uint8Array(module.HEAPU8.buffer,   dataPtr, totalLength).slice(); break;
+                        case NC_CONSTANTS.NC_SHORT:  data = new Int16Array(module.HEAP16.buffer,   dataPtr, totalLength).slice(); break;
+                        case NC_CONSTANTS.NC_USHORT: data = new Uint16Array(module.HEAPU16.buffer, dataPtr, totalLength).slice(); break;
+                        case NC_CONSTANTS.NC_INT:    data = new Int32Array(module.HEAP32.buffer,   dataPtr, totalLength).slice(); break;
+                        case NC_CONSTANTS.NC_UINT:   data = new Uint32Array(module.HEAPU32.buffer, dataPtr, totalLength).slice(); break;
+                        case NC_CONSTANTS.NC_INT64:  data = new BigInt64Array(module.HEAP64.buffer,  dataPtr, totalLength).slice(); break;
+                        case NC_CONSTANTS.NC_UINT64: data = new BigUint64Array(module.HEAPU64.buffer, dataPtr, totalLength).slice(); break;
+                    }
+                }
+                module._free(dataPtr); module._free(startPtr); module._free(countPtr); module._free(stridePtr);
                 return { result, data };
             },
         };


### PR DESCRIPTION
WIP:

This adds the `nc_get_vars_*` which will allow us to use `stride`s when reading variable data.

- A new `slice` class is added
- And a new method to get the data, e.g. `get("temperature", [slice(0,1), null, null])`, which mirrors fully the functionality from zarrita.

See: https://docs.unidata.ucar.edu/netcdf-c/current/group__variables.html#details